### PR TITLE
Parse env vars for username and API key

### DIFF
--- a/src/Volume.php
+++ b/src/Volume.php
@@ -265,7 +265,10 @@ class Volume extends FlysystemVolume
      */
     protected static function client($username, $apiKey)
     {
-        $config = ['username' => $username, 'apiKey' => $apiKey];
+        $config = [
+        	'username' => Craft::parseEnv($username),
+	        'apiKey' => Craft::parseEnv($apiKey)
+        ];
 
         $client = new Rackspace(Rackspace::US_IDENTITY_ENDPOINT, $config);
 

--- a/src/templates/volumeSettings.html
+++ b/src/templates/volumeSettings.html
@@ -1,19 +1,21 @@
 {% import "_includes/forms" as forms %}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
     label: "Username"|t('rackspace'),
     id: 'username',
     name: 'username',
+    suggestEnvVars: true,
     value: volume.username,
     errors: volume.getErrors('username'),
     class: 'rackspace-username',
     required: true
 }) }}
 
-{{ forms.textField({
+{{ forms.autosuggestField({
     label: "API Key"|t('rackspace'),
     id: 'apiKey',
     name: 'apiKey',
+    suggestEnvVars: true,
     value: volume.apiKey,
     errors: volume.getErrors('apiKey'),
     class: 'racskspace-api-key',

--- a/src/templates/volumeSettings.html
+++ b/src/templates/volumeSettings.html
@@ -1,21 +1,19 @@
 {% import "_includes/forms" as forms %}
 
-{{ forms.autosuggestField({
+{{ forms.textField({
     label: "Username"|t('rackspace'),
     id: 'username',
     name: 'username',
-    suggestEnvVars: true,
     value: volume.username,
     errors: volume.getErrors('username'),
     class: 'rackspace-username',
     required: true
 }) }}
 
-{{ forms.autosuggestField({
+{{ forms.textField({
     label: "API Key"|t('rackspace'),
     id: 'apiKey',
     name: 'apiKey',
-    suggestEnvVars: true,
     value: volume.apiKey,
     errors: volume.getErrors('apiKey'),
     class: 'racskspace-api-key',


### PR DESCRIPTION
I know this plugin is pretty much deprecated, but I'm having to work with it for a bit before transitioning off to something else. In the mean time, I didn't want to expose our API keys to the project config file.

This PR adds the ability to save the username and API Key as environment variables or aliases. Also updates those fields to be autosuggest fields to make retrieving them a bit easier.